### PR TITLE
Update rack for CVE-2020-8184

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     lita-fortune (0.0.8)
       i18n (~> 0.9)
       lita (>= 2.0)
+      rack (~> 2.1.4)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +23,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    lita (4.7.1)
+    lita (4.7.0)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
       http_router (>= 0.11.2)
@@ -30,7 +31,7 @@ GEM
       ice_nine (>= 0.11.0)
       multi_json (>= 1.7.7)
       puma (>= 2.7.1)
-      rack (>= 1.5.2, < 2.0.0)
+      rack (>= 1.5.2)
       rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
@@ -38,7 +39,7 @@ GEM
     nio4r (2.5.8)
     puma (5.6.1)
       nio4r (~> 2.0)
-    rack (1.6.13)
+    rack (2.1.4)
     rake (13.0.1)
     rb-readline (0.5.5)
     redis (4.6.0)

--- a/lita-fortune.gemspec
+++ b/lita-fortune.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '>= 2.0'
   spec.add_runtime_dependency 'i18n', '~> 0.9'
+  spec.add_runtime_dependency 'rack', '~> 2.1.4'
 
   spec.add_development_dependency 'bundler', '> 1.17'
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
Update for CVE: https://github.com/advisories/GHSA-j6w9-fv6q-3q52